### PR TITLE
Revert #7 to fix baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ permalink:        pretty
 title:               "S=k.logW"
 tagline:             "Molecular Stimulation"
 url:                 https://choderalab.github.io/klogw/
-baseurl:             ''
+baseurl:             https://choderalab.github.io/klogw/
 
 # About/contact
 author:


### PR DESCRIPTION
This seems to be the least broken (when used online) version.
