### PR TITLE
Post truncation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ permalink:        pretty
 title:               "S=k.logW"
 tagline:             "Molecular Stimulation"
 url:                 https://choderalab.github.io/klogw/
-baseurl:             https://choderalab.github.io/klogw/
+baseurl:             /
 
 # About/contact
 author:

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@ title: Home
 
     <span class="post-date">{{ post.date | date_to_string }}</span>
 
-    {{ post.content | strip_html | truncatewords:250, "..." }}
+    {{ post.content | strip_html | truncatewords:150, "..." }}
     <br>
     <a href="{{ post.url }}">Click here to read the full post</a>  
 

--- a/index.html
+++ b/index.html
@@ -36,7 +36,10 @@ title: Home
 
     <span class="post-date">{{ post.date | date_to_string }}</span>
 
-    {{ post.content }}
+    {{ post.content | strip_html | truncatewords:250, "..." }}
+    <br>
+    <a href="{{ post.url }}">Click here to read the full post</a>  
+
   </div>
   {% endfor %}
 </div>


### PR DESCRIPTION
I noticed that it is really hard to see where blog posts start and end, because the entire blog post gets displayed on the front page.

This is a suggestion that I've copied from my own blog (which isn't online yet). It truncates to 150 words, and displays a link to the full page at the bottom. Let me know what you guys think.

Also, I noticed that baseurl got reverted again. I assume it happened by accident. I added it to this PR, but it is easy to fix separately in case we decide not to merge this. 
