### PR TITLE
Add excerpt separators.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ paginate:         5
 
 # Custom vars
 version:          2.1.0
+excerpt_separator: "<!--more-->"
 
 github:
   repo:           https://github.com/choderalab/klogw

--- a/_posts/2016-06-26-introduction.md
+++ b/_posts/2016-06-26-introduction.md
@@ -14,6 +14,8 @@ As always, we appreciate your feedback! You can find us at [http://choderalab.or
 
 -----
 
+<!--more-->
+
 ### Blogging platform
 
 This site uses the [Hyde](https://github.com/poole/hyde) theme for [Jekyll](http://jekyllrb.com), the static site generator.

--- a/_posts/2016-07-14-how-to-write-a-methods-section.md
+++ b/_posts/2016-07-14-how-to-write-a-methods-section.md
@@ -15,6 +15,8 @@ To help prepare them to be better writers and communicators in the primary mediu
 I'm sharing this material in case others find it useful!
 Please feel free to provide feedback or suggestions as to how we can improve these resources and suggestions!
 
+<!--more-->
+
 ## Where should I start?
 
 There are some great resources available for writing scientific papers:

--- a/_posts/2016-08-15-fitting-the-correlation-function.md
+++ b/_posts/2016-08-15-fitting-the-correlation-function.md
@@ -14,6 +14,8 @@ contains all of the essential information of the trajectories in compact form an
 timescales in a model free way. Since the timescales for slow processes are invariant to the system, these timescales
 can be compared to timescales extracted through other means as a way to invalidate proposed kinetic models.
 
+<!--more-->
+
 The theoretical correlation function can be expressed as a sum of exponential $$ \mathbf C(t) = \sum_{i=1}^N A_i e^{-t/\tau_i } $$. The correlation function can also be computed from Markov State Models that were parameterized with many Molecular Dynamics trajectories as described in [this](http://www.sciencedirect.com/science/article/pii/S0301010411003892) paper, thus providing a way to directly connect simulations with experiments. 
 
 The naïve approach to find $$\mathbf {A_i} $$ and $$\mathbf {τ_i} $$ from the experimental correlation function is to use Ordinary Least Squares (OLS) to fit the experimental CF to this sum. If the error is Gaussian distributed and the errors are uncorrelated, OLS reduces to the Maximum Likelihood Estimate

--- a/_posts/2016-09-07-ncmc.md
+++ b/_posts/2016-09-07-ncmc.md
@@ -18,6 +18,8 @@ If we simulate long enough, time averages become good estimates for configuratio
 If the stochastic process we construct exhibits slow transitions between configurations (for example, due to high energy barriers between configurations), "long enough" can become prohibitive in cost.
 We’re interested in coming up with more efficient sampling methods to tackle this issue.
 
+<!--more-->
+
 ## What’s new in NCMC? 
 
 NCMC allows us to turn incomplete knowledge about a system into an efficient proposal.


### PR DESCRIPTION
This PR allows authors to use the `<!--more-->`  separator in their markdown file to indicate where their post should be truncated. I added it in what I thought were appropriate places in the existing posts. Feel free to edit. 
